### PR TITLE
Fix undefined reference to `yydebug' error

### DIFF
--- a/src/moc/moc.y
+++ b/src/moc/moc.y
@@ -95,7 +95,7 @@ char	*straddSpc( const char *, const char *,
 char	*straddSpc( const char *, const char *,
 		    const char *, const char * );
 
-extern int yydebug;
+//extern int yydebug;
 bool	   lexDebug	   = FALSE;
 bool	   grammarDebug	   = FALSE;
 int	   lineNo;				// current line number
@@ -857,8 +857,8 @@ int main( int argc, char **argv )
 		displayWarnings = FALSE;
 	    } else if ( opt == "ldbg" ) {	// lex debug output
 		lexDebug = TRUE;
-	    } else if ( opt == "ydbg" ) {	// yacc debug output
-		yydebug = TRUE;
+//	    } else if ( opt == "ydbg" ) {	// yacc debug output
+//		yydebug = TRUE;
 	    } else if ( opt == "dbg" ) {	// non-signal members are slots
 		grammarDebug = TRUE;
 	    } else {


### PR DESCRIPTION
The same error was fixed in Qt 2 port: https://github.com/heliocastro/qt2/pull/2

```
/usr/bin/ld: CMakeFiles/moc-qt1.dir/parser.cpp.o: in function `main':
parser.cpp:(.text+0x48a1): undefined reference to `yydebug'
```